### PR TITLE
Add nginx front-end

### DIFF
--- a/docker-svc/irida/Dockerfile
+++ b/docker-svc/irida/Dockerfile
@@ -10,7 +10,7 @@ ARG PW=galaxy
 RUN apt-get update; \
 	apt-get -y upgrade; \
 	apt-get install -f ; \
-	apt-get install perl fastqc -y; \
+	apt-get install perl fastqc nginx-full -y; \
 	rm -rf /var/lib/apt/lists/*; \
 	mkdir -p /etc/irida/plugins
 
@@ -43,7 +43,7 @@ RUN mkdir -p $IRIDA_DATA_DIR; \
 	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.2.3/tb-sample-report-pipeline-plugin-0.2.3-SNAPSHOT.jar"  -P /etc/irida/plugins/; \
 	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.1.2/snippy-tb-sample-iqtree-0.1.2-SNAPSHOT.jar" -P /etc/irida/plugins/; \
 	wget "${IRIDA_DOWNLOAD_URL}/${IRIDA_VERSION}/irida-${IRIDA_VERSION}.war"; \
-	mv irida-${IRIDA_VERSION}.war /usr/local/tomcat/webapps/irida.war
+	mv irida-${IRIDA_VERSION}.war /usr/local/tomcat/webapps/ROOT.war
 
 USER ${USER}
 
@@ -56,6 +56,10 @@ COPY etc-irida/static /etc/irida/static
 COPY etc-irida/templates /etc/irida/templates
 COPY *.sh ./
 
+COPY nginx-config /etc/nginx/sites-available/default
+COPY start-daemons.sh /usr/local/bin/start-daemons.sh
+RUN chmod a+x /usr/local/bin/start-daemons.sh
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-CMD ["./wait-for-it.sh", "irida_mysql:3306", "--", "catalina.sh", "run"]`
+CMD ["./wait-for-it.sh", "irida_mysql:3306", "--", "/usr/local/bin/start-daemons.sh"]

--- a/docker-svc/irida/nginx-config
+++ b/docker-svc/irida/nginx-config
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+
+  server_name    example.com;
+  access_log /var/log/nginx/tomcat-access.log;
+  error_log /var/log/nginx/tomcat-error.log;
+
+  location / {
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://127.0.0.1:8080;
+  }
+}

--- a/docker-svc/irida/start-daemons.sh
+++ b/docker-svc/irida/start-daemons.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+start-stop-daemon --pidfile /var/run/nginx --exec /usr/sbin/nginx -S -- -g 'daemon on; master_process on;'
+/usr/local/tomcat/bin/catalina.sh run


### PR DESCRIPTION
This moves the IRIDA war to the root of the Tomcat webapps directory and deploys nginx as a front end so that you can get IRIDA via normal HTTP.

This is not yet included in the docker-compose and does not yet support HTTPS.