### PR TITLE
Switch to MariaDB, export port 80 for IRIDA/nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,27 +10,23 @@ services:
     depends_on:
       - irida_mysql
     ports:
-      - "8080:8080"
+      - "80:80"
     volumes:
       - irida_web_data:/data/irida
 
   irida_mysql:
     restart: always
-    image: mysql:8.0
+    image: mariadb:10.5.6
     container_name: irida_mysql
     environment:
       MYSQL_ROOT_PASSWORD: rootpasswd
       MYSQL_DATABASE: irida_db
       MYSQL_USER: irida_user
       MYSQL_PASSWORD: irida_passwd
-    command: mysqld --sql_mode=""
     volumes:
       - irida_mysql_data:/var/lib/mysql
     ports:
       - "3306:3306"
-    cap_add:
-      - SYS_NICE  # CAP_SYS_NICE
-
 
   irida_galaxy:
     restart: always
@@ -54,3 +50,9 @@ volumes:
   irida_mysql_data:
   irida_web_data:
   irida_galaxy_data:
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1450

--- a/docker-svc/irida/Dockerfile
+++ b/docker-svc/irida/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
 	gosu nobody true;
 
 ENV COMBAT_TB_PLUGINS="https://github.com/COMBAT-TB/irida-pipeline-plugins" \
-    IRIDA_DOWNLOAD_URL="https://github.com/phac-nml/irida/releases/download/" \
+	IRIDA_DOWNLOAD_URL="https://github.com/phac-nml/irida/releases/download/" \
 	IRIDA_VERSION="20.09.2" \
 	IRIDA_DATA_DIR=/data/irida \
 	JAVA_OPTS="-Dspring.profiles.active=prod -Dirida.db.profile=prod" \
@@ -41,7 +41,7 @@ ENV COMBAT_TB_PLUGINS="https://github.com/COMBAT-TB/irida-pipeline-plugins" \
 RUN mkdir -p $IRIDA_DATA_DIR; \
 	bash -c "mkdir -p ${IRIDA_DATA_DIR}/{sequence,reference,output,assembly}"; \
 	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.2.3/tb-sample-report-pipeline-plugin-0.2.3-SNAPSHOT.jar"  -P /etc/irida/plugins/; \
-	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.1.2/snippy-tb-sample-iqtree-0.1.3.jar" -P /etc/irida/plugins/; \
+	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.1.2/snippy-tb-sample-iqtree-0.1.3-SNAPSHOT.jar" -P /etc/irida/plugins/; \
 	wget "${IRIDA_DOWNLOAD_URL}/${IRIDA_VERSION}/irida-${IRIDA_VERSION}.war"; \
 	mv irida-${IRIDA_VERSION}.war /usr/local/tomcat/webapps/ROOT.war
 
@@ -52,9 +52,10 @@ VOLUME $IRIDA_DATA_DIR
 USER root
 
 COPY *.conf /etc/irida/
+COPY *.sh ./
+
 COPY etc-irida/static /etc/irida/static
 COPY etc-irida/templates /etc/irida/templates
-COPY *.sh ./
 
 COPY nginx-config /etc/nginx/sites-available/default
 COPY start-daemons.sh /usr/local/bin/start-daemons.sh


### PR DESCRIPTION
MySQL 8 seemed to be causing some authentication related issues (perhaps related to their switch to a new authentication scheme), so this PR swaps it out for MariaDB and then exposes port 80 so that the nginx front-end server for IRIDA-web is visible.