### PR TITLE
Fix client_max_body_size and update plugins

### DIFF
--- a/docker-svc/irida/Dockerfile
+++ b/docker-svc/irida/Dockerfile
@@ -40,7 +40,7 @@ ENV COMBAT_TB_PLUGINS="https://github.com/COMBAT-TB/irida-pipeline-plugins" \
 
 RUN mkdir -p $IRIDA_DATA_DIR; \
 	bash -c "mkdir -p ${IRIDA_DATA_DIR}/{sequence,reference,output,assembly}"; \
-	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.2.3/tb-sample-report-pipeline-plugin-0.2.3-SNAPSHOT.jar"  -P /etc/irida/plugins/; \
+	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.2.3/tb-sample-report-pipeline-plugin-0.2.4-SNAPSHOT.jar"  -P /etc/irida/plugins/; \
 	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.1.2/snippy-tb-sample-iqtree-0.1.3.jar" -P /etc/irida/plugins/; \
 	wget "${IRIDA_DOWNLOAD_URL}/${IRIDA_VERSION}/irida-${IRIDA_VERSION}.war"; \
 	mv irida-${IRIDA_VERSION}.war /usr/local/tomcat/webapps/ROOT.war

--- a/docker-svc/irida/nginx-config
+++ b/docker-svc/irida/nginx-config
@@ -1,7 +1,8 @@
 server {
   listen 80;
 
-  server_name    example.com;
+  client_max_body_size 50g;
+
   access_log /var/log/nginx/tomcat-access.log;
   error_log /var/log/nginx/tomcat-error.log;
 


### PR DESCRIPTION
1. In nginx config change `client_max_body_size` to 50g to eliminate upload problems.
2. Update Dockerfile for IRIDA to pull latest plugins