### PR TITLE
Bump IRIDA version to 20.09.3

### DIFF
--- a/docker-svc/irida/Dockerfile
+++ b/docker-svc/irida/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex; \
 
 ENV COMBAT_TB_PLUGINS="https://github.com/COMBAT-TB/irida-pipeline-plugins" \
 	IRIDA_DOWNLOAD_URL="https://github.com/phac-nml/irida/releases/download/" \
-	IRIDA_VERSION="20.09.2" \
+	IRIDA_VERSION="20.09.3" \
 	IRIDA_DATA_DIR=/data/irida \
 	JAVA_OPTS="-Dspring.profiles.active=prod -Dirida.db.profile=prod" \
 	GALAXY_ADMIN_USER="admin@galaxy.org"


### PR DESCRIPTION
From source builds of IRIDA 20.09.2 are impacted by the problem addressed [here](https://github.com/phac-nml/irida/pull/869). This impacts on building IRIDA plugins. This PR simply updates IRIDA to 20.09.3 which does not have the build problem.