### PR TITLE
Update Galaxy, update plugins, switch to IRIDA 21.01

### DIFF
--- a/docker-svc/galaxy/Dockerfile
+++ b/docker-svc/galaxy/Dockerfile
@@ -35,3 +35,7 @@ RUN startup_lite && \
 
 # Container Style
 COPY *.png welcome.html $GALAXY_CONFIG_DIR/web/
+
+COPY galaxy.patch /tmp/galaxy.patch
+RUN apt install -y patch
+RUN cd / && patch -p1 </tmp/galaxy.patch

--- a/docker-svc/galaxy/combattb-tools.yml
+++ b/docker-svc/galaxy/combattb-tools.yml
@@ -97,6 +97,10 @@ tools:
     revisions:
       - "4f3f7d390382"
     tool_panel_section_label: "COMBAT-TB"
-
-
+  - name: "samtools_flagstat"
+    owner: "devteam"
+    tool_shed_url: "toolshed.g2.bx.psu.edu"
+    revisions:
+      - "22970df7a40e"
+    tool_panel_section_label: "COMBAT-TB"
 

--- a/docker-svc/galaxy/galaxy.patch
+++ b/docker-svc/galaxy/galaxy.patch
@@ -1,0 +1,11 @@
+--- a/galaxy-central/lib/galaxy/datatypes/data.py	2021-01-08 17:02:57.747469477 +0000
++++ b/galaxy-central/lib/galaxy/datatypes/data.py	2021-01-08 17:03:23.987603597 +0000
+@@ -435,7 +435,7 @@
+         from galaxy import datatypes  # DBTODO REMOVE THIS AT REFACTOR
+         if to_ext or isinstance(data.datatype, datatypes.binary.Binary):  # Saving the file, or binary file
+             if data.extension in composite_extensions:
+-                return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action'))
++                return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action','zip'))
+             else:
+                 trans.response.headers['Content-Length'] = int(os.stat(data.file_name).st_size)
+                 filename = self._download_filename(data, to_ext, hdca=kwd.get("hdca", None), element_identifier=kwd.get("element_identifier", None))

--- a/docker-svc/irida/Dockerfile
+++ b/docker-svc/irida/Dockerfile
@@ -31,17 +31,15 @@ RUN set -ex; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu nobody true;
 
-ENV COMBAT_TB_PLUGINS="https://github.com/COMBAT-TB/irida-pipeline-plugins" \
-	IRIDA_DOWNLOAD_URL="https://github.com/phac-nml/irida/releases/download/" \
-	IRIDA_VERSION="20.09.3" \
+ENV	IRIDA_DOWNLOAD_URL="https://github.com/phac-nml/irida/releases/download/" \
+	IRIDA_VERSION="21.01" \
 	IRIDA_DATA_DIR=/data/irida \
 	JAVA_OPTS="-Dspring.profiles.active=prod -Dirida.db.profile=prod" \
 	GALAXY_ADMIN_USER="admin@galaxy.org"
 
+
 RUN mkdir -p $IRIDA_DATA_DIR; \
 	bash -c "mkdir -p ${IRIDA_DATA_DIR}/{sequence,reference,output,assembly}"; \
-	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.2.4/tb-sample-report-pipeline-plugin-0.2.4.jar"  -P /etc/irida/plugins/; \
-	wget "${COMBAT_TB_PLUGINS}/releases/download/v0.1.4/snippy-tb-sample-iqtree-0.1.4.jar" -P /etc/irida/plugins/; \
 	wget "${IRIDA_DOWNLOAD_URL}/${IRIDA_VERSION}/irida-${IRIDA_VERSION}.war"; \
 	mv irida-${IRIDA_VERSION}.war /usr/local/tomcat/webapps/ROOT.war
 
@@ -60,6 +58,9 @@ COPY etc-irida/templates /etc/irida/templates
 COPY nginx-config /etc/nginx/sites-available/default
 COPY start-daemons.sh /usr/local/bin/start-daemons.sh
 RUN chmod a+x /usr/local/bin/start-daemons.sh
+
+RUN wget -P /etc/irida/plugins https://github.com/COMBAT-TB/irida-plugin-tb-sample-report/releases/download/0.3.1/tb-sample-report-pipeline-plugin-0.3.1.jar
+RUN wget -P /etc/irida/plugins https://github.com/COMBAT-TB/irida-plugin-tb-phylogeny/releases/download/0.1.4/tb-phylogeny-pipeline-plugin-0.1.4.jar
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 


### PR DESCRIPTION
* Patch Galaxy in Galaxy 20.09 Docker (fixes problem downloading zip composite types)
* Update to latest IRIDA plugins and new plugin deployment system
* Switch to IRIDA 21.01